### PR TITLE
This commit corrects the type declaration for the $navigationIcon pro…

### DIFF
--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -18,11 +18,12 @@ use Illuminate\Database\Eloquent\Collection;
 use App\Exports\OrdersExport;
 use Maatwebsite\Excel\Facades\Excel;
 use Filament\Tables\Actions\HeaderAction;
+use BackedEnum;
 
 class OrderResource extends Resource
 {
     protected static ?string $model = Order::class;
-    protected static ?string $navigationIcon = 'heroicon-o-shopping-cart';
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-shopping-cart';
     protected static ?string $navigationLabel = 'الطلبات';
     protected static ?int $navigationSort = 2;
 

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -10,11 +10,12 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Outerweb\FilamentTranslatableFields\Forms\Components\Translatable;
+use BackedEnum;
 
 class ProductResource extends Resource
 {
     protected static ?string $model = Product::class;
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-rectangle-stack';
     protected static ?string $navigationLabel = 'المنتجات';
     protected static ?int $navigationSort = 1;
 


### PR DESCRIPTION
…perty in ProductResource and OrderResource to match the parent Resource class in Filament v4. This resolves a fatal error that occurred when accessing the admin panel.